### PR TITLE
Added vscode's `setting.json` as tracked source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,5 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
-#VSCode
-.vscode
-
 #Artifacts
 **/target/**

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+	"java.checkstyle.configuration": "/google_checks.xml",
+	"java.configuration.updateBuildConfiguration": "automatic",
+	"java.project.sourcePaths": [
+        "is23am10/src"
+    ],
+    "java.project.outputPath": "bin",
+    "java.project.referencedLibraries": [
+        "lib/**/*.jar"
+    ],
+    "java.test.config": {
+        
+    },
+    "redhat.telemetry.enabled": false
+}

--- a/README.md
+++ b/README.md
@@ -6,22 +6,6 @@ Progetto Ingegneria del Software 2023
 
 - Open the project with VSCode Developer Docker [Container](https://code.visualstudio.com/docs/devcontainers/containers), hence build the container (for MacOS users `cmd+shift+p` and type "Build Container").
 - Enable Junit testing with Test runner extension that you will find in the tool bar, it will ask you to choose the verion to download, select `JUnit Jupiter`.
-	- Configure the `settings.json` adding the folloing in `.vscode/setting.json` (this local setting will overwrite your global setting.json)
-	```
-	"java.checkstyle.configuration": "/google_checks.xml",
-	"java.configuration.updateBuildConfiguration": "interactive",
-	"java.project.sourcePaths": [
-        "project/src"
-    ],
-    "java.project.outputPath": "bin",
-    "java.project.referencedLibraries": [
-        "lib/**/*.jar"
-    ],
-    "java.test.config": {
-        
-    },
-    "redhat.telemetry.enabled": false
-	```
 
 ## Code format
 Red Hat auto code formatter is available. Plese run `cmd+shift+p` + `Format document with` and select `Red Hat` option before committing.


### PR DESCRIPTION
### Notes
This addition saves a step in the dev container setup process making the whole experience less verbose.

### Test
/