### PR TITLE
Removed architectural docker dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN set -eux \
     && sed -i '/localpkg_gpgcheck=1/d' /etc/dnf/dnf.conf \
     && yum update \
     && yum install git -y \
-    && yum install -y tar.x86_64 \
+    && yum install -y tar \
     && yum install maven -y
 
 ENV LANG C.UTF-8


### PR DESCRIPTION
Removed the x86 version on tar in Dockerfile to allow Apple ARM-based computers to run the docker file. 