### PR TITLE
Made `AbstractPattern` generic

### DIFF
--- a/is23am10/src/main/java/it/polimi/is23am10/factory/GameFactory.java
+++ b/is23am10/src/main/java/it/polimi/is23am10/factory/GameFactory.java
@@ -1,11 +1,5 @@
 package it.polimi.is23am10.factory;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collector;
-import java.util.stream.Collectors;
-
 import it.polimi.is23am10.factory.exceptions.DuplicatePlayerNameException;
 import it.polimi.is23am10.factory.exceptions.NullPlayerNamesException;
 import it.polimi.is23am10.game.Game;
@@ -24,6 +18,11 @@ import it.polimi.is23am10.player.exceptions.NullPlayerNameException;
 import it.polimi.is23am10.player.exceptions.NullPlayerPrivateCardException;
 import it.polimi.is23am10.player.exceptions.NullPlayerScoreBlocksException;
 import it.polimi.is23am10.player.exceptions.NullPlayerScoreException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * The GameFactory class definition.
@@ -47,7 +46,7 @@ public final class GameFactory {
    * A list of already used {@link SharedPattern} instances.
    * 
    */
-  private static List<SharedPattern<Bookshelf>> usedSharedPatterns = new ArrayList<>();
+  private static List<SharedPattern<Predicate<Bookshelf>>> usedSharedPatterns = new ArrayList<>();
 
   /**
    * Create a new {@link Game} instance.

--- a/is23am10/src/main/java/it/polimi/is23am10/factory/PlayerFactory.java
+++ b/is23am10/src/main/java/it/polimi/is23am10/factory/PlayerFactory.java
@@ -17,6 +17,7 @@ import it.polimi.is23am10.score.Score;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.function.Function;
 
 /**
  * The PlayerFactory class definition.
@@ -33,7 +34,7 @@ public class PlayerFactory {
    * A list of already used {@link PrivatePattern} instances.
    * 
    */
-  private static List<PrivatePattern> usedPrivatePatterns = new ArrayList<>();
+  private static List<PrivatePattern<Function<Bookshelf, Integer>>> usedPrivatePatterns = new ArrayList<>();
 
   /**
    * Private constructor.

--- a/is23am10/src/main/java/it/polimi/is23am10/factory/PrivatePatternFactory.java
+++ b/is23am10/src/main/java/it/polimi/is23am10/factory/PrivatePatternFactory.java
@@ -436,19 +436,19 @@ public final class PrivatePatternFactory {
    * The list of {@link PrivatePattern} containing all the 12 different patterns.
    * 
    */
-  public static final List<PrivatePattern> patternsArray = List.of(
-      (new PrivatePattern(checkPattern1)),
-      (new PrivatePattern(checkPattern2)),
-      (new PrivatePattern(checkPattern3)),
-      (new PrivatePattern(checkPattern4)),
-      (new PrivatePattern(checkPattern5)),
-      (new PrivatePattern(checkPattern6)),
-      (new PrivatePattern(checkPattern7)),
-      (new PrivatePattern(checkPattern8)),
-      (new PrivatePattern(checkPattern9)),
-      (new PrivatePattern(checkPattern10)),
-      (new PrivatePattern(checkPattern11)),
-      (new PrivatePattern(checkPattern12)));
+  public static final List<PrivatePattern<Function<Bookshelf, Integer>>> patternsArray = List.of(
+      (new PrivatePattern<Function<Bookshelf, Integer>>(checkPattern1)),
+      (new PrivatePattern<Function<Bookshelf, Integer>>(checkPattern2)),
+      (new PrivatePattern<Function<Bookshelf, Integer>>(checkPattern3)),
+      (new PrivatePattern<Function<Bookshelf, Integer>>(checkPattern4)),
+      (new PrivatePattern<Function<Bookshelf, Integer>>(checkPattern5)),
+      (new PrivatePattern<Function<Bookshelf, Integer>>(checkPattern6)),
+      (new PrivatePattern<Function<Bookshelf, Integer>>(checkPattern7)),
+      (new PrivatePattern<Function<Bookshelf, Integer>>(checkPattern8)),
+      (new PrivatePattern<Function<Bookshelf, Integer>>(checkPattern9)),
+      (new PrivatePattern<Function<Bookshelf, Integer>>(checkPattern10)),
+      (new PrivatePattern<Function<Bookshelf, Integer>>(checkPattern11)),
+      (new PrivatePattern<Function<Bookshelf, Integer>>(checkPattern12)));
 
   /**
    * Method used to get random PrivatePattern between the 12 possible.
@@ -457,11 +457,12 @@ public final class PrivatePatternFactory {
    *                     patterns.
    * @return a random pattern between the 12 possible.
    */
-  public static PrivatePattern getNotUsedPattern(List<PrivatePattern> usedPatterns) {
+  public static PrivatePattern<Function<Bookshelf, Integer>> getNotUsedPattern(
+      List<PrivatePattern<Function<Bookshelf, Integer>>> usedPatterns) {
     if (usedPatterns.isEmpty()) {
       return patternsArray.get(random.nextInt(patternsArray.size()));
     } else {
-      List<PrivatePattern> unusedPatterns = patternsArray.stream()
+      List<PrivatePattern<Function<Bookshelf, Integer>>> unusedPatterns = patternsArray.stream()
           .filter(pattern -> !usedPatterns.contains(pattern))
           .collect(Collectors.toList());
       return unusedPatterns.get(random.nextInt(unusedPatterns.size()));

--- a/is23am10/src/main/java/it/polimi/is23am10/factory/SharedPatternFactory.java
+++ b/is23am10/src/main/java/it/polimi/is23am10/factory/SharedPatternFactory.java
@@ -578,27 +578,29 @@ public final class SharedPatternFactory {
    * rules with their lambda functions
    *
    */
-  private static final List<SharedPattern<Bookshelf>> patternsArray = List.of(
-      (new SharedPattern<>(checkTwoAdjacents,
+  private static final List<SharedPattern<Predicate<Bookshelf>>> patternsArray = List.of(
+      (new SharedPattern<Predicate<Bookshelf>>(checkTwoAdjacents,
           "Six separated groups made of two adjacent tiles of the same type. The tile type of different groups can be different.")),
-      (new SharedPattern<>(checkCornersMatch, "The four tiles at the corners of the bookshelf are of the same type.")),
-      (new SharedPattern<>(checkFourAdjacents,
+      (new SharedPattern<Predicate<Bookshelf>>(checkCornersMatch,
+          "The four tiles at the corners of the bookshelf are of the same type.")),
+      (new SharedPattern<Predicate<Bookshelf>>(checkFourAdjacents,
           "Four separated groups made of four adjacent tiles of the same type. The tile's type of different groups can be different.")),
-      (new SharedPattern<>(checkSquares,
+      (new SharedPattern<Predicate<Bookshelf>>(checkSquares,
           "Two groups of four tiles of the same type forming a 2x2 square shape. The tile type of the two squares has to be the same.")),
-      (new SharedPattern<>(checkMaxThreeTypesInColumn,
+      (new SharedPattern<Predicate<Bookshelf>>(checkMaxThreeTypesInColumn,
           "At least three full columns (filled with six tiles), having maximum three different tile types per column. ")),
-      (new SharedPattern<>(checkEightOfSameType,
+      (new SharedPattern<Predicate<Bookshelf>>(checkEightOfSameType,
           "At least eight tiles of the same type. There are no restrictions concerning their positions.")),
-      (new SharedPattern<>(checkDiagonalsSameType, "Five tiles of the same type forming a diagonal.")),
-      (new SharedPattern<>(checkMaxThreeTypesInRow,
+      (new SharedPattern<Predicate<Bookshelf>>(checkDiagonalsSameType,
+          "Five tiles of the same type forming a diagonal.")),
+      (new SharedPattern<Predicate<Bookshelf>>(checkMaxThreeTypesInRow,
           "At least four full rows (filled with five tiles), having maximum three different tile types per row.")),
-      (new SharedPattern<>(checkTwoColumnAllDiff,
+      (new SharedPattern<Predicate<Bookshelf>>(checkTwoColumnAllDiff,
           "At least two full columns (filled with six tiles), having tiles of all different types.")),
-      (new SharedPattern<>(checkTwoRowsAllDiff,
+      (new SharedPattern<Predicate<Bookshelf>>(checkTwoRowsAllDiff,
           "At least two full rows (filled with five tiles), having tiles of all different types.")),
-      (new SharedPattern<>(checkTilesXShape, "Five tiles of the same type, forming an X shape.")),
-      (new SharedPattern<>(checkOrderedBookshelfColumns,
+      (new SharedPattern<Predicate<Bookshelf>>(checkTilesXShape, "Five tiles of the same type, forming an X shape.")),
+      (new SharedPattern<Predicate<Bookshelf>>(checkOrderedBookshelfColumns,
           "Five columns with ascending or descending height. Starting from the first or the last column, the next column has to have one tile more. The tile types are not considered.")));
 
   /**
@@ -608,12 +610,12 @@ public final class SharedPatternFactory {
    *                     patterns.
    * @return a random pattern between the 12 possible.
    */
-  public static SharedPattern<Bookshelf> getNotUsedPattern(
-      List<SharedPattern<Bookshelf>> usedPatterns) {
+  public static SharedPattern<Predicate<Bookshelf>> getNotUsedPattern(
+      List<SharedPattern<Predicate<Bookshelf>>> usedPatterns) {
     if (usedPatterns.isEmpty()) {
       return patternsArray.get(random.nextInt(patternsArray.size()));
     } else {
-      List<SharedPattern<Bookshelf>> unusedPatterns = patternsArray.stream()
+      List<SharedPattern<Predicate<Bookshelf>>> unusedPatterns = patternsArray.stream()
           .filter(pattern -> !usedPatterns.contains(pattern))
           .collect(Collectors.toList());
       return unusedPatterns.get(random.nextInt(unusedPatterns.size()));

--- a/is23am10/src/main/java/it/polimi/is23am10/game/Game.java
+++ b/is23am10/src/main/java/it/polimi/is23am10/game/Game.java
@@ -29,7 +29,6 @@ import it.polimi.is23am10.player.exceptions.NullPlayerScoreBlocksException;
 import it.polimi.is23am10.player.exceptions.NullPlayerScoreException;
 import it.polimi.is23am10.utils.Coordinates;
 import it.polimi.is23am10.utils.exceptions.NullIndexValueException;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -210,10 +209,8 @@ public class Game {
   /**
    * The sharedCards setter.
    *
-   * @throws AlreadyInitiatedPatternException.
-   *
    */
-  public void setSharedCards(List<SharedCard> cards) throws AlreadyInitiatedPatternException {
+  public void setSharedCards(List<SharedCard> cards) {
     this.sharedCards = new ArrayList<>();
     sharedCards.add(cards.get(0));
     sharedCards.add(cards.get(1));
@@ -232,7 +229,8 @@ public class Game {
   /**
    * The lastRound setter.
    * 
-   * @param lastRound A flag referencing if the game is in its last round of rounds.
+   * @param lastRound A flag referencing if the game is in its last round of
+   *                  rounds.
    *
    */
   public void setLastRound() {
@@ -349,9 +347,9 @@ public class Game {
     Optional<Player> player = players.stream()
         .filter(p -> p.getPlayerName().equals(playerName))
         .findFirst();
-    if(player.isPresent()){
+    if (player.isPresent()) {
       return player.get();
-    }else{
+    } else {
       throw new PlayerNotFoundException();
     }
   }
@@ -399,7 +397,6 @@ public class Game {
   public Player getWinnerPlayer() {
     return this.winnerPlayer;
   }
-  
 
   /**
    * Method that computes active player's Score, updates the view,
@@ -419,7 +416,7 @@ public class Game {
     checkWin();
     activePlayer.updateScore();
     gameBoard.refillIfNeeded();
-    int idxNextPlayer = (getPlayers().indexOf(activePlayer) + 1) % getPlayers().size() ;
+    int idxNextPlayer = (getPlayers().indexOf(activePlayer) + 1) % getPlayers().size();
     if (lastRound && idxNextPlayer == players.indexOf(winnerPlayer)) {
       setEnded(true);
       return;
@@ -457,8 +454,10 @@ public class Game {
   }
 
   /**
-   * Function that checks if there's a winner and sets flags of lastRound and ended
+   * Function that checks if there's a winner and sets flags of lastRound and
+   * ended
    * accordingly.
+   * 
    * @throws NullPlayerException
    * 
    */
@@ -502,7 +501,7 @@ public class Game {
    */
   public void activePlayerMove(Map<Coordinates, Coordinates> selectedCoordinates)
       throws BoardGridColIndexOutOfBoundsException, BoardGridRowIndexOutOfBoundsException,
-      InvalidBoardTileSelectionException, NullIndexValueException, BookshelfGridColIndexOutOfBoundsException,
+      NullIndexValueException, BookshelfGridColIndexOutOfBoundsException,
       BookshelfGridRowIndexOutOfBoundsException, NullTileException, NullPlayerBookshelfException,
       NullScoreBlockListException, NullPlayerException {
     for (Map.Entry<Coordinates, Coordinates> entry : selectedCoordinates.entrySet()) {

--- a/is23am10/src/main/java/it/polimi/is23am10/items/card/AbstractCard.java
+++ b/is23am10/src/main/java/it/polimi/is23am10/items/card/AbstractCard.java
@@ -14,19 +14,13 @@ import it.polimi.is23am10.pattern.AbstractPattern;
  * @param T The type of the assigned
  *          {@link AbstractPattern}.
  */
-public abstract class AbstractCard<T extends AbstractPattern> {
+public abstract class AbstractCard<R, T extends AbstractPattern<R>> {
 
   /**
    * The pattern instance.
    * Its type must extends {@link AbstractPattern}
    */
   private T pattern;
-
-  /**
-   * The instance id.
-   * TODO: maybe unused
-   */
-  private int id;
 
   /**
    * Pattern setter.

--- a/is23am10/src/main/java/it/polimi/is23am10/items/card/PrivateCard.java
+++ b/is23am10/src/main/java/it/polimi/is23am10/items/card/PrivateCard.java
@@ -1,12 +1,13 @@
 package it.polimi.is23am10.items.card;
 
-import java.util.List;
-
 import it.polimi.is23am10.factory.PrivatePatternFactory;
+import it.polimi.is23am10.items.bookshelf.Bookshelf;
 import it.polimi.is23am10.items.card.exceptions.AlreadyInitiatedPatternException;
 import it.polimi.is23am10.items.card.exceptions.NegativeMatchedBlockCountException;
 import it.polimi.is23am10.items.card.exceptions.NullMatchedBlockCountException;
 import it.polimi.is23am10.pattern.PrivatePattern;
+import java.util.List;
+import java.util.function.Function;
 
 /**
  * Private card class definition.
@@ -16,7 +17,8 @@ import it.polimi.is23am10.pattern.PrivatePattern;
  * @author Kaixi Matteo Chen (kaiximatteo.chen@mail.polimi.it)
  * @author Lorenzo Cavallero (lorenzo1.cavallero@mail.polimi.it)
  */
-public class PrivateCard extends AbstractCard<PrivatePattern> {
+public class PrivateCard
+    extends AbstractCard<Function<Bookshelf, Integer>, PrivatePattern<Function<Bookshelf, Integer>>> {
 
   /**
    * A counter for the number of matched blocks in the {@link PrivatePattern}.
@@ -27,11 +29,13 @@ public class PrivateCard extends AbstractCard<PrivatePattern> {
   /**
    * Constructor.
    * 
-   * @param usedPrivatePatterns is a list of PrivatePattern used to store the already
-   *                     used one.
+   * @param usedPrivatePatterns is a list of PrivatePattern used to store the
+   *                            already
+   *                            used one.
    * @throws AlreadyInitiatedPatternException
    */
-  public PrivateCard(List<PrivatePattern> usedPrivatePatterns) throws AlreadyInitiatedPatternException {
+  public PrivateCard(List<PrivatePattern<Function<Bookshelf, Integer>>> usedPrivatePatterns)
+      throws AlreadyInitiatedPatternException {
     matchedBlocksCount = 0;
     setPattern(PrivatePatternFactory.getNotUsedPattern(usedPrivatePatterns));
   }

--- a/is23am10/src/main/java/it/polimi/is23am10/items/card/SharedCard.java
+++ b/is23am10/src/main/java/it/polimi/is23am10/items/card/SharedCard.java
@@ -1,14 +1,14 @@
 package it.polimi.is23am10.items.card;
 
+import it.polimi.is23am10.factory.SharedPatternFactory;
 import it.polimi.is23am10.items.bookshelf.Bookshelf;
 import it.polimi.is23am10.items.card.exceptions.AlreadyInitiatedPatternException;
 import it.polimi.is23am10.items.card.exceptions.NullScoreBlockListException;
 import it.polimi.is23am10.items.scoreblock.ScoreBlock;
 import it.polimi.is23am10.pattern.SharedPattern;
-import it.polimi.is23am10.factory.SharedPatternFactory;
-
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * Shared card object.
@@ -18,7 +18,7 @@ import java.util.List;
  * @author Kaixi Matteo Chen (kaiximatteo.chen@mail.polimi.it)
  * @author Lorenzo Cavallero (lorenzo1.cavallero@mail.polimi.it)
  */
-public class SharedCard extends AbstractCard<SharedPattern<Bookshelf>> {
+public class SharedCard extends AbstractCard<Predicate<Bookshelf>, SharedPattern<Predicate<Bookshelf>>> {
 
   /**
    * A list of {@link ScoreBlock} instances.
@@ -28,13 +28,15 @@ public class SharedCard extends AbstractCard<SharedPattern<Bookshelf>> {
    */
   private List<ScoreBlock> scoreBlocks;
 
-   /**
-    * Constructor.
-    *
-    * @param usedPatterns is a list of SharedPattern used to store the already used.
-    * @throws AlreadyInitiatedPatternException
-    */
-  public SharedCard(List<SharedPattern<Bookshelf>> usedSharedPatterns) throws AlreadyInitiatedPatternException {
+  /**
+   * Constructor.
+   *
+   * @param usedPatterns is a list of SharedPattern used to store the already
+   *                     used.
+   * @throws AlreadyInitiatedPatternException
+   */
+  public SharedCard(List<SharedPattern<Predicate<Bookshelf>>> usedSharedPatterns)
+      throws AlreadyInitiatedPatternException {
     scoreBlocks = new ArrayList<>();
     setPattern(SharedPatternFactory.getNotUsedPattern(usedSharedPatterns));
   }

--- a/is23am10/src/main/java/it/polimi/is23am10/pattern/AbstractPattern.java
+++ b/is23am10/src/main/java/it/polimi/is23am10/pattern/AbstractPattern.java
@@ -8,12 +8,30 @@ package it.polimi.is23am10.pattern;
  * @author Kaixi Matteo Chen (kaiximatteo.chen@mail.polimi.it)
  * @author Lorenzo Cavallero (lorenzo1.cavallero@mail.polimi.it)
  */
-public abstract class AbstractPattern {
+public abstract class AbstractPattern<T> {
 
   /**
-   * The pattern id.
+   * The assigned rule to this pattern.
    * 
    */
-  private Integer id;
+  protected T rule;
 
+  /**
+   * Constructor.
+   * 
+   * @param rule The rule assigned to the current pattern..
+   * 
+   */
+  protected AbstractPattern(T rule) {
+    this.rule = rule;
+  }
+
+  /**
+   * Rule getter.
+   *
+   * @return The rule function.
+   */
+  public T getRule() {
+    return rule;
+  }
 }

--- a/is23am10/src/main/java/it/polimi/is23am10/pattern/PrivatePattern.java
+++ b/is23am10/src/main/java/it/polimi/is23am10/pattern/PrivatePattern.java
@@ -1,8 +1,5 @@
 package it.polimi.is23am10.pattern;
 
-import it.polimi.is23am10.items.bookshelf.Bookshelf;
-import java.util.function.Function;
-
 /**
  * Private pattern object.
  *
@@ -11,31 +8,15 @@ import java.util.function.Function;
  * @author Kaixi Matteo Chen (kaiximatteo.chen@mail.polimi.it)
  * @author Lorenzo Cavallero (lorenzo1.cavallero@mail.polimi.it)
  */
-public class PrivatePattern extends AbstractPattern {
-
-  /**
-   * A {@link Function} that implements a specific rule,
-   * which retrieves the number of bookshelf tiles belonging to a player
-   * that match the private card assigned to that player.
-   */
-  private Function<Bookshelf, Integer> rule;
+public class PrivatePattern<T> extends AbstractPattern<T> {
 
   /**
    * The constructor of the class PrivatePattern.
    *
    * @param rule a function that takes a Bookshelf object and returns an Integer.
    */
-  public PrivatePattern(Function<Bookshelf, Integer> rule) {
-    this.rule = rule;
-  }
-
-  /**
-   * Rule getter.
-   *
-   * @return The rule function.
-   */
-  public Function<Bookshelf, Integer> getRule() {
-    return rule;
+  public PrivatePattern(T rule) {
+    super(rule);
   }
 
   /**
@@ -47,7 +28,7 @@ public class PrivatePattern extends AbstractPattern {
     if (!(obj instanceof PrivatePattern)) {
       return false;
     }
-    return this.rule == ((PrivatePattern) obj).getRule();
+    return this.rule == ((PrivatePattern<T>) obj).getRule();
   }
 
   /**

--- a/is23am10/src/main/java/it/polimi/is23am10/pattern/SharedPattern.java
+++ b/is23am10/src/main/java/it/polimi/is23am10/pattern/SharedPattern.java
@@ -12,13 +12,7 @@ import it.polimi.is23am10.items.bookshelf.Bookshelf;
  * @author Kaixi Matteo Chen (kaiximatteo.chen@mail.polimi.it)
  * @author Lorenzo Cavallero (lorenzo1.cavallero@mail.polimi.it)
  */
-public class SharedPattern<T extends Bookshelf> extends AbstractPattern {
-
-  /**
-   * A {@link Predicate} instance applying the given rule.
-   * 
-   */
-  private Predicate<T> rule;
+public class SharedPattern<T> extends AbstractPattern<T> {
 
   /**
    * A string describing the pattern.
@@ -30,18 +24,9 @@ public class SharedPattern<T extends Bookshelf> extends AbstractPattern {
    * The constructor of the class SharedPattern.
    *
    */
-  public SharedPattern(Predicate<T> rule, String description) {
-    this.rule = rule;
+  public SharedPattern(T rule, String description) {
+    super(rule);
     this.patternDescription = description;
-  }
-
-  /**
-   * Rule getter.
-   *
-   * @return The rule function.
-   */
-  public Predicate<T> getRule() {
-    return rule;
   }
 
   /**
@@ -62,8 +47,8 @@ public class SharedPattern<T extends Bookshelf> extends AbstractPattern {
     if (!(obj instanceof SharedPattern )) {
       return false;
     }
-    return this.rule == ((SharedPattern<Bookshelf>) obj).getRule()
-        && this.patternDescription.equals(((SharedPattern<Bookshelf>) obj).getPatternDescription());
+    return this.rule == ((SharedPattern<T>) obj).getRule()
+        && this.patternDescription.equals(((SharedPattern<T>) obj).getPatternDescription());
   }
 
   /**

--- a/is23am10/src/test/java/it/polimi/is23am10/factory/PrivatePatternFactoryTest.java
+++ b/is23am10/src/test/java/it/polimi/is23am10/factory/PrivatePatternFactoryTest.java
@@ -21,6 +21,7 @@ import it.polimi.is23am10.player.exceptions.NullPlayerPrivateCardException;
 import it.polimi.is23am10.player.exceptions.NullPlayerScoreBlocksException;
 import it.polimi.is23am10.player.exceptions.NullPlayerScoreException;
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,7 +32,7 @@ public class PrivatePatternFactoryTest {
    * @throws WrongLengthBookshelfStringException
    * @throws WrongCharBookshelfStringException
    * @throws NullPointerException
-
+   * 
    */
 
   @BeforeEach
@@ -42,8 +43,7 @@ public class PrivatePatternFactoryTest {
 
   @Test
   public void RULE1_should_find_ZERO_matches()
-      throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException
-       {
+      throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException {
     Bookshelf testPattern1ZeroMatches = new Bookshelf(
         "CCCGF" +
             "FTBFF" +
@@ -57,8 +57,7 @@ public class PrivatePatternFactoryTest {
 
   @Test
   public void RULE1_should_find_SIX_matches()
-      throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException
-       {
+      throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException {
     Bookshelf testPattern1 = new Bookshelf(
         "PCFGF" +
             "FTBFC" +
@@ -72,8 +71,7 @@ public class PrivatePatternFactoryTest {
 
   @Test
   public void RULE2_should_find_ZERO_matches()
-      throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException
-       {
+      throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException {
     Bookshelf testPattern2ZeroMatches = new Bookshelf(
         "CCBGF" +
             "FFBFC" +
@@ -87,8 +85,7 @@ public class PrivatePatternFactoryTest {
 
   @Test
   public void RULE2_should_find_SIX_matches()
-      throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException
-       {
+      throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException {
     Bookshelf testPattern2 = new Bookshelf(
         "CCBGF" +
             "FPBFC" +
@@ -102,8 +99,7 @@ public class PrivatePatternFactoryTest {
 
   @Test
   public void RULE3_should_find_ZERO_matches()
-      throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException
-       {
+      throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException {
     Bookshelf testPattern3ZeroMatches = new Bookshelf(
         "CCBGF" +
             "BTBBC" +
@@ -117,8 +113,7 @@ public class PrivatePatternFactoryTest {
 
   @Test
   public void RULE3_should_find_SIX_matches()
-      throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException
-       {
+      throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException {
     Bookshelf testPattern3 = new Bookshelf(
         "CCBGF" +
             "FTBGC" +
@@ -132,8 +127,7 @@ public class PrivatePatternFactoryTest {
 
   @Test
   public void RULE4_should_find_ZERO_matches()
-      throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException
-       {
+      throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException {
     Bookshelf testPattern4ZeroMatches = new Bookshelf(
         "CCBGF" +
             "FTBFC" +
@@ -148,8 +142,7 @@ public class PrivatePatternFactoryTest {
 
   @Test
   public void RULE4_should_find_SIX_matches()
-      throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException
-       {
+      throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException {
     Bookshelf testPattern4 = new Bookshelf(
         "CCBGG" +
             "FTBFC" +
@@ -163,8 +156,7 @@ public class PrivatePatternFactoryTest {
 
   @Test
   public void RULE5_should_find_ZERO_matches()
-      throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException
-       {
+      throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException {
     Bookshelf testPattern5ZeroMatches = new Bookshelf(
         "CCBGF" +
             "FCBFC" +
@@ -178,8 +170,7 @@ public class PrivatePatternFactoryTest {
 
   @Test
   public void RULE5_should_find_SIX_matches()
-      throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException
-       {
+      throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException {
     Bookshelf testPattern5 = new Bookshelf(
         "CCBGF" +
             "FTBFC" +
@@ -193,8 +184,7 @@ public class PrivatePatternFactoryTest {
 
   @Test
   public void RULE6_should_find_ZERO_matches()
-      throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException
-       {
+      throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException {
     Bookshelf testPattern6ZeroMatches = new Bookshelf(
         "CCFGF" +
             "FTBFC" +
@@ -208,8 +198,7 @@ public class PrivatePatternFactoryTest {
 
   @Test
   public void RULE6_should_find_SIX_matches()
-      throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException
-       {
+      throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException {
     Bookshelf testPattern6 = new Bookshelf(
         "CCTGC" +
             "FTBFC" +
@@ -251,7 +240,7 @@ public class PrivatePatternFactoryTest {
 
   @Test
   public void RULE8_should_find_ZERO_matches()
-  throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException {
+      throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException {
     Bookshelf testPattern8ZeroMatches = new Bookshelf(
         "CCBGB" +
             "FBBFC" +
@@ -265,7 +254,7 @@ public class PrivatePatternFactoryTest {
 
   @Test
   public void RULE8_should_find_SIX_matches()
-  throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException {
+      throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException {
     Bookshelf testPattern8 = new Bookshelf(
         "CCBGF" +
             "FCBFC" +
@@ -279,7 +268,7 @@ public class PrivatePatternFactoryTest {
 
   @Test
   public void RULE9_should_find_ZERO_matches()
-  throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException {
+      throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException {
     Bookshelf testPattern9ZeroMatches = new Bookshelf(
         "CCPGF" +
             "FTBFC" +
@@ -293,7 +282,7 @@ public class PrivatePatternFactoryTest {
 
   @Test
   public void RULE9_should_find_SIX_matches()
-  throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException {
+      throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException {
     Bookshelf testPattern9 = new Bookshelf(
         "CCGGF" +
             "FTBFC" +
@@ -307,7 +296,7 @@ public class PrivatePatternFactoryTest {
 
   @Test
   public void RULE10_should_find_ZERO_matches()
-  throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException {
+      throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException {
     Bookshelf testPattern10ZeroMatches = new Bookshelf(
         "CCBGP" +
             "FPBFC" +
@@ -321,7 +310,7 @@ public class PrivatePatternFactoryTest {
 
   @Test
   public void RULE10_should_find_SIX_matches()
-  throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException {
+      throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException {
     Bookshelf testPattern10 = new Bookshelf(
         "CCBGT" +
             "FGBFC" +
@@ -335,7 +324,7 @@ public class PrivatePatternFactoryTest {
 
   @Test
   public void RULE11_should_find_ZERO_matches()
-  throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException {
+      throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException {
     Bookshelf testPattern11ZeroMatches = new Bookshelf(
         "CCFGF" +
             "FFBFC" +
@@ -349,7 +338,7 @@ public class PrivatePatternFactoryTest {
 
   @Test
   public void RULE11_should_find_SIX_matches()
-  throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException {
+      throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException {
     Bookshelf testPattern11 = new Bookshelf(
         "CCPGF" +
             "FBBFC" +
@@ -363,7 +352,7 @@ public class PrivatePatternFactoryTest {
 
   @Test
   public void RULE12_should_find_ZERO_matches()
-  throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException {
+      throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException {
     Bookshelf testPattern12ZeroMatches = new Bookshelf(
         "CCFGF" +
             "FFBFC" +
@@ -378,7 +367,7 @@ public class PrivatePatternFactoryTest {
 
   @Test
   public void RULE12_should_find_SIX_matches()
-  throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException {
+      throws WrongLengthBookshelfStringException, WrongCharBookshelfStringException, NullPointerException {
     Bookshelf testPattern12 = new Bookshelf(
         "CCBGF" +
             "FPBFC" +
@@ -394,14 +383,15 @@ public class PrivatePatternFactoryTest {
   public void TEST_GET_RANDOM_PRIVATECARDS_no_duplicates()
       throws AlreadyInitiatedPatternException, NullPlayerNameException, NullPlayerIdException,
       NullPlayerBookshelfException, NullPlayerScoreException, NullPlayerPrivateCardException,
-      NullPlayerScoreBlocksException, DuplicatePlayerNameException, NullPlayerNamesException, NullMaxPlayerException, InvalidMaxPlayerException, InvalidNumOfPlayersException, NullNumOfPlayersException {
+      NullPlayerScoreBlocksException, DuplicatePlayerNameException, NullPlayerNamesException, NullMaxPlayerException,
+      InvalidMaxPlayerException, InvalidNumOfPlayersException, NullNumOfPlayersException {
     Game game = GameFactory.getNewGame("firstPlayer", 4);
     game.addPlayer("secondPlayer");
     game.addPlayer("thirdPlayer");
     game.addPlayer("fourthPlayer");
 
-    List<PrivatePattern> allUsedPatterns
-        = game.getPlayers().stream().map(player -> player.getPrivateCard().getPattern()).distinct().collect(Collectors.toList());
+    List<PrivatePattern<Function<Bookshelf, Integer>>> allUsedPatterns = game.getPlayers().stream()
+        .map(player -> player.getPrivateCard().getPattern()).distinct().collect(Collectors.toList());
 
     assertEquals(4, allUsedPatterns.size());
   }

--- a/is23am10/src/test/java/it/polimi/is23am10/factory/SharedPatternFactoryTest.java
+++ b/is23am10/src/test/java/it/polimi/is23am10/factory/SharedPatternFactoryTest.java
@@ -23,6 +23,7 @@ import it.polimi.is23am10.player.exceptions.NullPlayerPrivateCardException;
 import it.polimi.is23am10.player.exceptions.NullPlayerScoreBlocksException;
 import it.polimi.is23am10.player.exceptions.NullPlayerScoreException;
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -559,8 +560,8 @@ public class SharedPatternFactoryTest {
 
     Game game = GameFactory.getNewGame("firstPlayer", 4);
 
-    List<SharedPattern<Bookshelf>> allUsedPatterns
-        = game.getSharedCard().stream().map(card -> card.getPattern()).distinct().collect(Collectors.toList());
+    List<SharedPattern<Predicate<Bookshelf>>> allUsedPatterns = game.getSharedCard().stream()
+        .map(card -> card.getPattern()).distinct().collect(Collectors.toList());
 
     assertEquals(2, allUsedPatterns.size());
   }

--- a/is23am10/src/test/java/it/polimi/is23am10/items/card/PrivateCardTest.java
+++ b/is23am10/src/test/java/it/polimi/is23am10/items/card/PrivateCardTest.java
@@ -6,10 +6,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 
 import it.polimi.is23am10.factory.PrivatePatternFactory;
+import it.polimi.is23am10.items.bookshelf.Bookshelf;
 import it.polimi.is23am10.items.card.exceptions.AlreadyInitiatedPatternException;
 import it.polimi.is23am10.items.card.exceptions.NegativeMatchedBlockCountException;
 import it.polimi.is23am10.items.card.exceptions.NullMatchedBlockCountException;
@@ -18,12 +20,13 @@ import it.polimi.is23am10.pattern.PrivatePattern;
 public class PrivateCardTest {
   /**
    * Green path test for constructor.
+   * 
    * @throws AlreadyInitiatedPatternException
    */
   @Test
   public void constructor_should_create_PrivateCard() throws AlreadyInitiatedPatternException {
     final Integer ZERO = 0;
-    final List<PrivatePattern> emptyList = new ArrayList<PrivatePattern>();
+    final List<PrivatePattern<Function<Bookshelf, Integer>>> emptyList = new ArrayList<PrivatePattern<Function<Bookshelf, Integer>>>();
     PrivateCard pc = new PrivateCard(emptyList);
 
     assertNotNull(pc);
@@ -34,23 +37,27 @@ public class PrivateCardTest {
   /**
    * Testing setPattern throwing exception, when trying
    * to set a new pattern on an already instantiated one.
+   * 
    * @throws AlreadyInitiatedPatternException
    */
   @Test
   public void setPattern_should_throw_AlreadyInitiatedPatternException() throws AlreadyInitiatedPatternException {
-    final List<PrivatePattern> emptyList = new ArrayList<PrivatePattern>();
+    final List<PrivatePattern<Function<Bookshelf, Integer>>> emptyList = new ArrayList<PrivatePattern<Function<Bookshelf, Integer>>>();
     PrivateCard pc = new PrivateCard(emptyList);
-    assertThrows(AlreadyInitiatedPatternException.class, () -> pc.setPattern(PrivatePatternFactory.getNotUsedPattern(emptyList)));
+    assertThrows(AlreadyInitiatedPatternException.class,
+        () -> pc.setPattern(PrivatePatternFactory.getNotUsedPattern(emptyList)));
   }
 
   /**
    * Testing exception when setting a null number of
    * matched blocks.
+   * 
    * @throws AlreadyInitiatedPatternException
    */
   @Test
-  public void setMatchedBlocksCount_should_throw_NullMatchedBlockCountException() throws AlreadyInitiatedPatternException {
-    final List<PrivatePattern> emptyList = new ArrayList<PrivatePattern>();
+  public void setMatchedBlocksCount_should_throw_NullMatchedBlockCountException()
+      throws AlreadyInitiatedPatternException {
+    final List<PrivatePattern<Function<Bookshelf, Integer>>> emptyList = new ArrayList<PrivatePattern<Function<Bookshelf, Integer>>>();
     PrivateCard pc = new PrivateCard(emptyList);
     assertThrows(NullMatchedBlockCountException.class, () -> pc.setMatchedBlocksCount(null));
   }
@@ -58,12 +65,14 @@ public class PrivateCardTest {
   /**
    * Testing exception when setting a negative number of
    * matched blocks.
+   * 
    * @throws AlreadyInitiatedPatternException
    */
   @Test
-  public void setMatchedBlocksCount_should_throw_NegativeMatchedBlockCountException() throws AlreadyInitiatedPatternException {
+  public void setMatchedBlocksCount_should_throw_NegativeMatchedBlockCountException()
+      throws AlreadyInitiatedPatternException {
     final Integer NEGATIVE_VAL = -1;
-    final List<PrivatePattern> emptyList = new ArrayList<PrivatePattern>();
+    final List<PrivatePattern<Function<Bookshelf, Integer>>> emptyList = new ArrayList<PrivatePattern<Function<Bookshelf, Integer>>>();
     PrivateCard pc = new PrivateCard(emptyList);
     assertThrows(NegativeMatchedBlockCountException.class, () -> pc.setMatchedBlocksCount(NEGATIVE_VAL));
   }

--- a/is23am10/src/test/java/it/polimi/is23am10/items/card/SharedCardTest.java
+++ b/is23am10/src/test/java/it/polimi/is23am10/items/card/SharedCardTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertThrows;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
@@ -19,11 +20,12 @@ import it.polimi.is23am10.pattern.SharedPattern;
 public class SharedCardTest {
   /**
    * Green path test for constructor.
+   * 
    * @throws AlreadyInitiatedPatternException
    */
   @Test
   public void constructor_should_create_SharedCard() throws AlreadyInitiatedPatternException {
-    final List<SharedPattern<Bookshelf>> emptyList = new ArrayList<SharedPattern<Bookshelf>>();
+    final List<SharedPattern<Predicate<Bookshelf>>> emptyList = new ArrayList<SharedPattern<Predicate<Bookshelf>>>();
     SharedCard sc = new SharedCard(emptyList);
 
     assertNotNull(sc);
@@ -34,38 +36,42 @@ public class SharedCardTest {
   /**
    * Testing setPattern throwing exception, when trying
    * to set a new pattern on an already instantiated one.
+   * 
    * @throws AlreadyInitiatedPatternException
    */
   @Test
   public void setPattern_should_throw_AlreadyInitiatedPatternException() throws AlreadyInitiatedPatternException {
-    final List<SharedPattern<Bookshelf>> emptyList = new ArrayList<SharedPattern<Bookshelf>>();
+    final List<SharedPattern<Predicate<Bookshelf>>> emptyList = new ArrayList<SharedPattern<Predicate<Bookshelf>>>();
     SharedCard sc = new SharedCard(emptyList);
-    assertThrows(AlreadyInitiatedPatternException.class, () -> sc.setPattern(SharedPatternFactory.getNotUsedPattern(emptyList)));
+    assertThrows(AlreadyInitiatedPatternException.class,
+        () -> sc.setPattern(SharedPatternFactory.getNotUsedPattern(emptyList)));
   }
 
   /**
    * Testing exception when setting a null scoreBlock array.
+   * 
    * @throws AlreadyInitiatedPatternException
    */
   @Test
   public void setScoreBlocks_should_throw_NullScoreBlockListException() throws AlreadyInitiatedPatternException {
-    final List<SharedPattern<Bookshelf>> emptyList = new ArrayList<SharedPattern<Bookshelf>>();
+    final List<SharedPattern<Predicate<Bookshelf>>> emptyList = new ArrayList<SharedPattern<Predicate<Bookshelf>>>();
     SharedCard sc = new SharedCard(emptyList);
     assertThrows(NullScoreBlockListException.class, () -> sc.setScoreBlocks(null));
   }
 
   /**
    * Testing Green Path for setScoreBlocks.
+   * 
    * @throws AlreadyInitiatedPatternException
    * @throws NullScoreBlockListException
    */
   @Test
-  public void setScoreBlocks_should_set_scoreblocks() 
+  public void setScoreBlocks_should_set_scoreblocks()
       throws AlreadyInitiatedPatternException, NullScoreBlockListException {
-    
-    final List<SharedPattern<Bookshelf>> emptyList = new ArrayList<SharedPattern<Bookshelf>>();
+
+    final List<SharedPattern<Predicate<Bookshelf>>> emptyList = new ArrayList<SharedPattern<Predicate<Bookshelf>>>();
     SharedCard sc = new SharedCard(emptyList);
-    final ArrayList arr = new ArrayList<ScoreBlock>();
+    final ArrayList<ScoreBlock> arr = new ArrayList<ScoreBlock>();
 
     sc.setScoreBlocks(arr);
     assertEquals(arr, sc.getScoreBlocks());

--- a/is23am10/src/test/java/it/polimi/is23am10/player/PlayerTest.java
+++ b/is23am10/src/test/java/it/polimi/is23am10/player/PlayerTest.java
@@ -29,10 +29,13 @@ import it.polimi.is23am10.player.exceptions.NullPlayerScoreBlocksException;
 import it.polimi.is23am10.player.exceptions.NullPlayerScoreException;
 import it.polimi.is23am10.score.Score;
 import it.polimi.is23am10.utils.exceptions.NullIndexValueException;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
+import java.util.function.Function;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -171,7 +174,7 @@ public class PlayerTest {
     @Test
     public void setPrivateCard_should_set_PrivateCard()
         throws NullPlayerPrivateCardException, AlreadyInitiatedPatternException {
-      List<PrivatePattern> usedPatterns = new ArrayList<>();
+      List<PrivatePattern<Function<Bookshelf, Integer>>> usedPatterns = new ArrayList<>();
       PrivateCard dummyPrivateCard = new PrivateCard(usedPatterns);
       p.setPrivateCard(dummyPrivateCard);
       assertNotNull(p.getPrivateCard());
@@ -277,7 +280,7 @@ public class PlayerTest {
         new ScoreBlock(2),
         new ScoreBlock(4)));
 
-    List<PrivatePattern> usedPatterns = new ArrayList<>();
+    List<PrivatePattern<Function<Bookshelf, Integer>>> usedPatterns = new ArrayList<>();
     PrivateCard pc = new PrivateCard(usedPatterns);
     pc.setMatchedBlocksCount(SIX);
     p.setPrivateCard(pc);

--- a/is23am10/src/test/java/it/polimi/is23am10/score/ScoreTest.java
+++ b/is23am10/src/test/java/it/polimi/is23am10/score/ScoreTest.java
@@ -21,12 +21,12 @@ import it.polimi.is23am10.utils.exceptions.NullIndexValueException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-
 
 public class ScoreTest {
   @Test
@@ -38,7 +38,7 @@ public class ScoreTest {
     assertEquals(zero, s.getScoreBlockPoints());
     assertEquals(zero, s.getPrivatePoints());
   }
-    
+
   @Test
   public void setExtraPoint_should_set_extraPoint() {
     Score s = new Score();
@@ -52,7 +52,7 @@ public class ScoreTest {
     /**
      * This test comes directly from the rulebook.
      * Check Rulebook - page 2 - Final count example.
-  
+     * 
      * @throws WrongCharBookshelfStringException
      * @throws WrongLengthBookshelfStringException
      * @throws NullPointerException
@@ -62,41 +62,43 @@ public class ScoreTest {
      * @throws NullPlayerBookshelfException
      */
     @Test
-    public void setBookshelfPoints_should_set_exampleBS() 
+    public void setBookshelfPoints_should_set_exampleBS()
         throws NullPointerException, WrongLengthBookshelfStringException, WrongCharBookshelfStringException,
-        BookshelfGridColIndexOutOfBoundsException, BookshelfGridRowIndexOutOfBoundsException, NullIndexValueException, NullPlayerBookshelfException {
+        BookshelfGridColIndexOutOfBoundsException, BookshelfGridRowIndexOutOfBoundsException, NullIndexValueException,
+        NullPlayerBookshelfException {
       Score s = new Score();
       Bookshelf bs = new Bookshelf(
           "PPPXX" +
-          "BPPCX" +
-          "FBFBX" +
-          "TGTGX" +
-          "TTCCC" + 
-          "TTTCC"
-      );
+              "BPPCX" +
+              "FBFBX" +
+              "TGTGX" +
+              "TTCCC" +
+              "TTTCC");
 
       s.setBookshelfPoints(bs);
       final Integer EIGHTEEN = 18;
 
-      assertEquals(EIGHTEEN, s.getBookshelfPoints());   
+      assertEquals(EIGHTEEN, s.getBookshelfPoints());
     }
 
     /**
-     * This test checks that an empty bookshelf 
+     * This test checks that an empty bookshelf
      * returns a zero score.
+     * 
      * @throws NullPointerException
      * @throws WrongLengthBookshelfStringException
      * @throws WrongCharBookshelfStringException
-  
+     * 
      * @throws BookshelfGridColIndexOutOfBoundsException
      * @throws BookshelfGridRowIndexOutOfBoundsException
      * @throws NullIndexValueException
      * @throws NullPlayerBookshelfException
      */
     @Test
-    public void setBookshelfPoints_should_set_emptyBS() 
+    public void setBookshelfPoints_should_set_emptyBS()
         throws NullPointerException, WrongLengthBookshelfStringException, WrongCharBookshelfStringException,
-        BookshelfGridColIndexOutOfBoundsException, BookshelfGridRowIndexOutOfBoundsException, NullIndexValueException, NullPlayerBookshelfException {
+        BookshelfGridColIndexOutOfBoundsException, BookshelfGridRowIndexOutOfBoundsException, NullIndexValueException,
+        NullPlayerBookshelfException {
       Score s = new Score();
       Bookshelf bs = new Bookshelf();
 
@@ -109,67 +111,69 @@ public class ScoreTest {
     /**
      * This tests checks that groups bigger than {@link Score#MAX_GROUP_SIZE}
      * only count as {@link Score#MAX_GROUP_SIZE}-big groups.
+     * 
      * @throws NullPointerException
      * @throws WrongLengthBookshelfStringException
      * @throws WrongCharBookshelfStringException
-  
+     * 
      * @throws BookshelfGridColIndexOutOfBoundsException
      * @throws BookshelfGridRowIndexOutOfBoundsException
      * @throws NullIndexValueException
      * @throws NullPlayerBookshelfException
      */
     @Test
-    public void setBookshelfPoints_should_set_bigGroupsBS() 
+    public void setBookshelfPoints_should_set_bigGroupsBS()
         throws NullPointerException, WrongLengthBookshelfStringException, WrongCharBookshelfStringException,
-        BookshelfGridColIndexOutOfBoundsException, BookshelfGridRowIndexOutOfBoundsException, NullIndexValueException, NullPlayerBookshelfException {
+        BookshelfGridColIndexOutOfBoundsException, BookshelfGridRowIndexOutOfBoundsException, NullIndexValueException,
+        NullPlayerBookshelfException {
       Score s = new Score();
       Bookshelf bs = new Bookshelf(
           "PPPPP" +
-          "PPPPP" +
-          "PPPPP" +
-          "CCCCC" +
-          "CCCCC" + 
-          "CCCCC"
-      );
+              "PPPPP" +
+              "PPPPP" +
+              "CCCCC" +
+              "CCCCC" +
+              "CCCCC");
 
       s.setBookshelfPoints(bs);
       // Two groups of 6+ should be counted as two groups of 6
       // returning 2x8 = 16 score
       final Integer SIXTEEN = 16;
 
-      assertEquals(SIXTEEN, s.getBookshelfPoints());   
+      assertEquals(SIXTEEN, s.getBookshelfPoints());
     }
 
     /**
      * This tests checks that groups smaller than {@link Score#MIN_GROUP_SIZE}
      * get ignored.
+     * 
      * @throws NullPointerException
      * @throws WrongLengthBookshelfStringException
      * @throws WrongCharBookshelfStringException
-  
+     * 
      * @throws BookshelfGridColIndexOutOfBoundsException
      * @throws BookshelfGridRowIndexOutOfBoundsException
      * @throws NullIndexValueException
      * @throws NullPlayerBookshelfException
      */
     @Test
-    public void setBookshelfPoints_should_set_smallGroupsBS() 
+    public void setBookshelfPoints_should_set_smallGroupsBS()
         throws NullPointerException, WrongLengthBookshelfStringException, WrongCharBookshelfStringException,
-        BookshelfGridColIndexOutOfBoundsException, BookshelfGridRowIndexOutOfBoundsException, NullIndexValueException, NullPlayerBookshelfException {
+        BookshelfGridColIndexOutOfBoundsException, BookshelfGridRowIndexOutOfBoundsException, NullIndexValueException,
+        NullPlayerBookshelfException {
       Score s = new Score();
       Bookshelf bs = new Bookshelf(
           "PCPCP" +
-          "CPCPC" +
-          "PCPCP" +
-          "CPCPC" +
-          "PCPCP" + 
-          "CPCPC"
-      );
+              "CPCPC" +
+              "PCPCP" +
+              "CPCPC" +
+              "PCPCP" +
+              "CPCPC");
 
       s.setBookshelfPoints(bs);
       final Integer ZERO = 0;
 
-      assertEquals(ZERO, s.getBookshelfPoints());   
+      assertEquals(ZERO, s.getBookshelfPoints());
     }
   }
 
@@ -183,10 +187,11 @@ public class ScoreTest {
     public void setScoreBlockPoints_should_throw_NullScoreBlockListException() {
       Score s = new Score();
       assertThrows(NullScoreBlockListException.class, () -> s.setScoreBlockPoints(null));
-    } 
+    }
 
     /**
      * Test to check green path. Scoreblocks are present and valid
+     * 
      * @throws NotValidScoreBlockValueException
      * @throws NullScoreBlockListException
      */
@@ -195,8 +200,7 @@ public class ScoreTest {
       Score s = new Score();
       List<ScoreBlock> list = List.of(
           new ScoreBlock(2),
-          new ScoreBlock(4)
-      );
+          new ScoreBlock(4));
 
       s.setScoreBlockPoints(list);
 
@@ -209,11 +213,13 @@ public class ScoreTest {
     /**
      * Test to check that an empty list of scoreblocks
      * results in a zero-score.
+     * 
      * @throws NotValidScoreBlockValueException
      * @throws NullScoreBlockListException
      */
     @Test
-    public void setScoreBlockPoints_should_set_empty() throws NotValidScoreBlockValueException, NullScoreBlockListException {
+    public void setScoreBlockPoints_should_set_empty()
+        throws NotValidScoreBlockValueException, NullScoreBlockListException {
       Score s = new Score();
       List<ScoreBlock> list = List.of();
 
@@ -227,7 +233,7 @@ public class ScoreTest {
   @Nested
   class setPrivatePoints_tests {
 
-    private List<PrivatePattern> usedPatterns = new ArrayList<>();
+    private List<PrivatePattern<Function<Bookshelf, Integer>>> usedPatterns = new ArrayList<>();
 
     /**
      * Test to check exception throws.
@@ -236,10 +242,11 @@ public class ScoreTest {
     public void setPrivatePoints_should_throw_NullPointerException() {
       Score s = new Score();
       assertThrows(NullPointerException.class, () -> s.setPrivatePoints(null));
-    } 
+    }
 
     /**
-     * Test to check green path. Private 
+     * Test to check green path. Private
+     * 
      * @throws NotValidScoreBlockValueException
      * @throws NullScoreBlockListException
      * @throws AlreadyInitiatedPatternException
@@ -247,10 +254,11 @@ public class ScoreTest {
      * @throws NullMatchedBlockCountException
      */
     @ParameterizedTest
-    @ValueSource(ints = {0,1,2,3,4,5,6})
-    public void setPrivatePoints_should_set(Integer value) throws NotValidScoreBlockValueException, NullScoreBlockListException,
+    @ValueSource(ints = { 0, 1, 2, 3, 4, 5, 6 })
+    public void setPrivatePoints_should_set(Integer value)
+        throws NotValidScoreBlockValueException, NullScoreBlockListException,
         AlreadyInitiatedPatternException, NullMatchedBlockCountException, NegativeMatchedBlockCountException {
-        
+
       Score s = new Score();
       PrivateCard pc = new PrivateCard(usedPatterns);
       pc.setMatchedBlocksCount(value);


### PR DESCRIPTION
## Notes

Overriding @locavallero  as this change needs to be done before any new feature to avoid a fallback of collisions.

### What was wrong
Currently `SharedPattern` and `PrivatePattern` are inheriting from a parent class (`AbstractPattern`) with a meaningless implementation as no shared attributes/methods are available (empty inheritance).

Introduced Java generics to make the `rule` field type assignable when declaring the children class hence supporting more `rule` types in the future if needed (outside `Function` and `Predicate`).

## Test
`mvn package`
